### PR TITLE
Previene el error IndexOutOfBoundsException

### DIFF
--- a/src/main/java/upeu/edu/pe/project_lp2_gp2/infrastructure/controller/HomeController.java
+++ b/src/main/java/upeu/edu/pe/project_lp2_gp2/infrastructure/controller/HomeController.java
@@ -53,7 +53,12 @@ public class HomeController {
         log.info("Id product: {}", id);
         log.info("stock size: {}", stocks.size());
         log.info("stock : {}", stocks);
-        Integer lastBalance = stocks.get(stocks.size() - 1).getBalance();
+        Integer lastBalance = 0;
+
+        if (!stocks.isEmpty()) {
+            StockEntity lastStock = stocks.get(stocks.size() - 1);
+            lastBalance = lastStock.getBalance();
+        }
 
         model.addAttribute("product", productService.getProductById(id));
         model.addAttribute("stock", lastBalance);


### PR DESCRIPTION
Previene el error de IndexOutOfBoundsException, estableciendo el lastBalance como 0, luego comprobando el tamaño del stock para ver si se sobrepasa el tamaño del stock.

Este error puede ocurrir cuando el producto no tiene stock
Cuando el producto no tiene stock, el tamaño del stock es 0.
Y cuando intentamos acceder al ultimo stock `stocks.get(stocks.size() - 1).getBalance()` tendremos un error IndexOutOfBoundsException por intentar acceder al item -1.